### PR TITLE
Fix webpack to work

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,14 +4,7 @@ module.exports = {
     browser: true,
     node: true,
   },
-  extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-  ],
-  parser: "@typescript-eslint/parser",
+  extends: ["eslint:recommended"],
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",
@@ -19,10 +12,26 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ["@typescript-eslint"],
   rules: {
     semi: ["error", "always"],
     indent: ["error", 2],
-    "react/prop-types": "off",
   },
+  overrides: [
+    {
+      files: ["**/*.{ts,tsx}"],
+      extends: [
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+      ],
+      parser: "@typescript-eslint/parser",
+      plugins: ["@typescript-eslint"],
+    },
+    {
+      files: ["**/*.{jsx,tsx}"],
+      extends: ["plugin:react/recommended", "plugin:react-hooks/recommended"],
+      rules: {
+        "react/prop-types": "off",
+      },
+    },
+  ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import path from "path";
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const path = require("path");
 
 const common = {
   plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,7 @@ const prod = {
   mode: "production",
 };
 
-module.exports = function (env, argv) {
+module.exports = function () {
   if (process.env.NODE_ENV === "production") {
     return { ...common, ...prod };
   } else {


### PR DESCRIPTION
#2 

- #8 https://github.com/n-inokawa/react-typescript-example/pull/8/commits/4e8e01158f875828068bca1d2b20d76af58e5899 の修正で`yarn start`及び`yarn build`が動作しなくなっていた問題対応
  - overridesを活用し、typescript用のeslint設定が.jsに当たらないよう修正した